### PR TITLE
Prevent default double-click behavior

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,6 +16,11 @@ window.addEventListener("load", function () {
         }
     });
 
+    // Prevent double-click zooming on mobile devices
+    document.ondblclick = function (e) {
+        e.preventDefault();
+    }
+
     // Submit Name
     document.querySelector("#name-submit").addEventListener("submit", function (e) {
         e.preventDefault();


### PR DESCRIPTION
On some mobile devices, clicking twice in rapid succession will toggle a zoom feature.

This isn't usually a problem except when **trying to allocate stats at the start of a run**: adding or removing points from a stat too quickly will register as a double click and zoom in while also preventing the onClick events from firing for a moment.

This is a quick fix that works for me on a newer iPhone, and shouldn't have any unintended consequences unless you are planning on implementing a mechanic that requires double clicking.